### PR TITLE
Update enum colums to support correct mysql enum indexing

### DIFF
--- a/pymysqlreplication/column.py
+++ b/pymysqlreplication/column.py
@@ -72,8 +72,8 @@ class Column(object):
     def __read_enum_metadata(self, column_schema):
         enums = column_schema["COLUMN_TYPE"]
         if self.type == FIELD_TYPE.ENUM:
-            self.enum_values = enums.replace('enum(', '')\
-                .replace(')', '').replace('\'', '').split(',')
+            self.enum_values = [''] + enums.replace('enum(', '').\
+                replace(')', '').replace('\'', '').split(',')
         else:
             self.set_values = enums.replace('set(', '')\
                 .replace(')', '').replace('\'', '').split(',')

--- a/pymysqlreplication/row_event.py
+++ b/pymysqlreplication/row_event.py
@@ -162,7 +162,7 @@ class RowsEvent(BinLogEvent):
                 values[name] = self.packet.read_uint8() + 1900
             elif column.type == FIELD_TYPE.ENUM:
                 values[name] = column.enum_values[
-                    self.packet.read_uint_by_size(column.size) - 1]
+                    self.packet.read_uint_by_size(column.size)]
             elif column.type == FIELD_TYPE.SET:
                 # We read set columns as a bitmap telling us which options
                 # are enabled

--- a/pymysqlreplication/tests/test_data_type.py
+++ b/pymysqlreplication/tests/test_data_type.py
@@ -378,6 +378,18 @@ class TestDataType(base.PyMySQLReplicationTestCase):
         self.assertEqual(event.rows[0]["values"]["test"], 'ba')
         self.assertEqual(event.rows[0]["values"]["test2"], 'a')
 
+    def test_enum_empty_string(self):
+        create_query = "CREATE TABLE test (test ENUM('a', 'ba', 'c'), test2 ENUM('a', 'ba', 'c')) CHARACTER SET latin1 COLLATE latin1_bin;"
+        insert_query = "INSERT INTO test VALUES('ba', 'asdf')"
+        last_sql_mode = self.execute("SELECT @@SESSION.sql_mode;"). \
+            fetchall()[0][0]
+        self.execute("SET SESSION sql_mode = 'ANSI';")
+        event = self.create_and_insert_value(create_query, insert_query)
+        self.execute("SET SESSION sql_mode = '%s';" % last_sql_mode)
+
+        self.assertEqual(event.rows[0]["values"]["test"], 'ba')
+        self.assertEqual(event.rows[0]["values"]["test2"], '')
+
     def test_set(self):
         create_query = "CREATE TABLE test (test SET('a', 'ba', 'c'), test2 SET('a', 'ba', 'c')) CHARACTER SET latin1 COLLATE latin1_bin;"
         insert_query = "INSERT INTO test VALUES('ba,a,c', 'a,c')"


### PR DESCRIPTION
When an enum value is stored in mysql it represent the index of the value (for `type=enum('a','b','c')` 1 represent 'a' ext... ) also, 0 represents the empty string. (when a wrong value is inserted to an enum column it will be saved as an empty string)

When the package got an enum type it changed the indexes so ('a', 'b', 'c') will be mapped to (0, 1, 2), and it transformed the values from the bin-log accordingly. So value 1 (which is 'a' in this exemp) will be changed to 0 ect.. 
If a value 0 was received it will be transformed to -1 which in python will be 'c' as index `-1` points to the last member of the list.

To solve this i added the empty string by default to an enum column metadata and removed the value transformation so that (0, 1, 2, 3)  will be mapped to -> ('', 'a', 'b', 'c')