### PR TITLE
Fix checksum supporting check

### DIFF
--- a/pymysqlreplication/binlogstream.py
+++ b/pymysqlreplication/binlogstream.py
@@ -18,7 +18,7 @@ from .event import (
 from .exceptions import BinLogNotEnabled
 from .row_event import (
     UpdateRowsEvent, WriteRowsEvent, DeleteRowsEvent, TableMapEvent)
-from utils import Utils
+import utils
 
 try:
     from pymysql.constants.COMMAND import COM_BINLOG_DUMP_GTID
@@ -284,7 +284,7 @@ class BinLogStreamReader(object):
         # we support it too
         server_version = self.__get_server_version()
 
-        if Utils.is_checksum_supported(server_version):
+        if utils.is_checksum_supported(server_version):
             cur = self._stream_connection.cursor()
             cur.execute("set @master_binlog_checksum = 'CRC32'")
             cur.close()

--- a/pymysqlreplication/binlogstream.py
+++ b/pymysqlreplication/binlogstream.py
@@ -18,6 +18,7 @@ from .event import (
 from .exceptions import BinLogNotEnabled
 from .row_event import (
     UpdateRowsEvent, WriteRowsEvent, DeleteRowsEvent, TableMapEvent)
+from utils import Utils
 
 try:
     from pymysql.constants.COMMAND import COM_BINLOG_DUMP_GTID
@@ -282,8 +283,8 @@ class BinLogStreamReader(object):
         # If the server support checksum we need to inform it that
         # we support it too
         server_version = self.__get_server_version()
-        if "5.6.1" <= server_version or \
-                (("mariadb" in server_version) and ("5.3" <= server_version)):
+
+        if Utils.is_checksum_supported(server_version):
             cur = self._stream_connection.cursor()
             cur.execute("set @master_binlog_checksum = 'CRC32'")
             cur.close()

--- a/pymysqlreplication/binlogstream.py
+++ b/pymysqlreplication/binlogstream.py
@@ -18,7 +18,7 @@ from .event import (
 from .exceptions import BinLogNotEnabled
 from .row_event import (
     UpdateRowsEvent, WriteRowsEvent, DeleteRowsEvent, TableMapEvent)
-import utils
+from pymysqlreplication import utils
 
 try:
     from pymysql.constants.COMMAND import COM_BINLOG_DUMP_GTID

--- a/pymysqlreplication/event.py
+++ b/pymysqlreplication/event.py
@@ -7,7 +7,8 @@ import datetime
 import chardet
 
 from pymysql.util import byte2int, int2byte
-from utils import Utils
+import utils
+
 
 class BinLogEvent(object):
     def __init__(self, from_packet, event_size, table_map, ctl_connection,
@@ -112,7 +113,7 @@ class FormatDescriptionEvent(BinLogEvent):
         self.binlog_version = struct.unpack('<H', self.packet.read(2))[0]
         self.server_version = self.packet.read(50).rstrip(b'\x00').decode()
         self.has_checksum = False
-        if Utils.is_checksum_supported(self.server_version):
+        if utils.is_checksum_supported(self.server_version):
             event_size_without_header = self.packet.event_size - 19
             # skip event types and stop reading before 5 last chars that
             # representing checksum algorithm (1) + checksum (4)

--- a/pymysqlreplication/event.py
+++ b/pymysqlreplication/event.py
@@ -7,7 +7,7 @@ import datetime
 import chardet
 
 from pymysql.util import byte2int, int2byte
-
+from utils import Utils
 
 class BinLogEvent(object):
     def __init__(self, from_packet, event_size, table_map, ctl_connection,
@@ -112,8 +112,7 @@ class FormatDescriptionEvent(BinLogEvent):
         self.binlog_version = struct.unpack('<H', self.packet.read(2))[0]
         self.server_version = self.packet.read(50).rstrip(b'\x00').decode()
         self.has_checksum = False
-        if "5.6.1" <= self.server_version or \
-                (("mariadb" in self.server_version) and ("5.3" <= self.server_version)):
+        if Utils.is_checksum_supported(self.server_version):
             event_size_without_header = self.packet.event_size - 19
             # skip event types and stop reading before 5 last chars that
             # representing checksum algorithm (1) + checksum (4)

--- a/pymysqlreplication/event.py
+++ b/pymysqlreplication/event.py
@@ -7,7 +7,7 @@ import datetime
 import chardet
 
 from pymysql.util import byte2int, int2byte
-import utils
+from pymysqlreplication import utils
 
 
 class BinLogEvent(object):

--- a/pymysqlreplication/tests/test_utils.py
+++ b/pymysqlreplication/tests/test_utils.py
@@ -8,19 +8,19 @@ class TextUtils(unittest.TestCase):
     def test_is_checksum_supported(self):
         # regular supported mysql version
         server_version = '5.7.17-log'
-        assert utils.is_checksum_supported(server_version) == True
+        assert utils.is_checksum_supported(server_version) is True
 
         # mariaDB supported mysql version
         server_version = '10.2.11-MariaDB-10.2.11+maria~jessie-log'
-        assert utils.is_checksum_supported(server_version) == True
+        assert utils.is_checksum_supported(server_version) is True
 
         # regular unsupported mysql version
         server_version = '5.3.1-log'
-        assert utils.is_checksum_supported(server_version) == False
+        assert utils.is_checksum_supported(server_version) is False
 
         # mariaDB unsupported mysql version
         server_version = '5.2.11-MariaDB'
-        assert utils.is_checksum_supported(server_version) == False
+        assert utils.is_checksum_supported(server_version) is False
 
         server_version = '5.2.11-mariadb'
-        assert utils.is_checksum_supported(server_version) == False
+        assert utils.is_checksum_supported(server_version) is False

--- a/pymysqlreplication/tests/test_utils.py
+++ b/pymysqlreplication/tests/test_utils.py
@@ -1,0 +1,26 @@
+import unittest
+import pytest
+from pymysqlreplication import utils
+
+
+class TextUtils(unittest.TestCase):
+
+    def test_is_checksum_supported(self):
+        # regular supported mysql version
+        server_version = '5.7.17-log'
+        assert utils.is_checksum_supported(server_version) == True
+
+        # mariaDB supported mysql version
+        server_version = '10.2.11-MariaDB-10.2.11+maria~jessie-log'
+        assert utils.is_checksum_supported(server_version) == True
+
+        # regular unsupported mysql version
+        server_version = '5.3.1-log'
+        assert utils.is_checksum_supported(server_version) == False
+
+        # mariaDB unsupported mysql version
+        server_version = '5.2.11-MariaDB'
+        assert utils.is_checksum_supported(server_version) == False
+
+        server_version = '5.2.11-mariadb'
+        assert utils.is_checksum_supported(server_version) == False

--- a/pymysqlreplication/utils.py
+++ b/pymysqlreplication/utils.py
@@ -1,0 +1,15 @@
+import re
+from pkg_resources import parse_version
+
+
+class Utils:
+    def is_checksum_supported(self, server_version):
+
+        version_number = \
+            parse_version(re.findall('^([\d\.]+)', server_version)[0])
+        if parse_version('5.6.1') <= version_number or \
+                (("mariadb" in server_version.lower()) and
+                 (parse_version('5.3') <= version_number)):
+                return True
+
+        return False

--- a/pymysqlreplication/utils.py
+++ b/pymysqlreplication/utils.py
@@ -2,14 +2,12 @@ import re
 from pkg_resources import parse_version
 
 
-class Utils:
-    def is_checksum_supported(self, server_version):
+def is_checksum_supported(server_version):
+    version_number = \
+        parse_version(re.findall('^([\d\.]+)', server_version)[0])
+    if parse_version('5.6.1') <= version_number or \
+            (("mariadb" in server_version.lower()) and
+             (parse_version('5.3') <= version_number)):
+            return True
 
-        version_number = \
-            parse_version(re.findall('^([\d\.]+)', server_version)[0])
-        if parse_version('5.6.1') <= version_number or \
-                (("mariadb" in server_version.lower()) and
-                 (parse_version('5.3') <= version_number)):
-                return True
-
-        return False
+    return False


### PR DESCRIPTION
In case of mariaDB, getVersion query might return the value '10.2.11-MariaDB-10.2.11+maria~jessie-log'
So, '"mariadb" in server_version' check will return False due to capital letters issue.
In addition, '"5.6.1" <= server_version' also return False because "5.6.1">"10.2.11..." in lexicographic order